### PR TITLE
Default options must be applied on optionnal props

### DIFF
--- a/src/layer.ts
+++ b/src/layer.ts
@@ -75,11 +75,11 @@ export class IIIFLayer extends TileLayer {
                   DEFAULT_OPTIONS,
                   // Server pref
                   {
-                    tileSize: this.server.tileSize,
-                    tileFormat: this.server.formats[0],
-                    quality: this.server.qualities.includes("native") ? "native" : "default",
-                    minZoom: this.server.minZoom,
-                    maxZoom: this.server.maxZoom,
+                    tileSize: this.server.tileSize || DEFAULT_OPTIONS.tileSize,
+                    tileFormat: this.server.formats[0] || DEFAULT_OPTIONS.tileFormat,
+                    quality: this.server.qualities && this.server.qualities.includes("native") ? "native" : "default",
+                    minZoom: this.server.minZoom || DEFAULT_OPTIONS.minZoom,
+                    maxZoom: this.server.maxZoom || DEFAULT_OPTIONS.maxZoom,
                   },
                   // User's options
                   options,

--- a/src/types.ts
+++ b/src/types.ts
@@ -121,8 +121,8 @@ export const DEFAULT_OPTIONS: IIIFLayerOptions = {
   mirroring: false,
   fitBounds: true,
   setMaxBounds: false,
-  minZoom: 0,
-  maxZoom: 0,
+  minZoom: -2,
+  maxZoom: 2,
   zoomOffset: 0,
 };
 


### PR DESCRIPTION
Only appear with some minimal v1.1 spec files
such as https://gallica.bnf.fr/iiif/ark:/12148/btv1b83045172/f1/info.json

Default Zoom options has been updated to allow minimal zooming experience in those cases.